### PR TITLE
[naming] substitute pairwise by minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 https://github.com/avocado-framework/avocado-vt/ uses cartesian_config to create list of test cases over the largest possible set of test parameter combinations, i.e. variants.
 
-The `pairwise` takes a list of test case names (p1.p2.p3, e.g. virsh.domstats.argument) and filters out test cases whose test parameter values, represented by the variant name, have already been covered in another test case earlier in the list.
+The `minimal` function takes a list of test case names (p1.p2.p3, e.g. virsh.domstats.argument) and filters out test cases whose test parameter values, represented by the variant name, have already been covered in another test case earlier in the list.
 
 An example of what will be filtered can be seen in the unit test.
 
@@ -8,7 +8,7 @@ Example:
 
 A filtered output could look like:
 ```bash
-# python3 filter_avocado_list.py -s virsh.boot,boot_integration
+# python3 minimal_avocado_list.py -s virsh.boot,boot_integration
 virsh.boot.loadparm
 virsh.boot.by_seabios.positive_test.options.boot.hd.file_disk.boot_dev.os_loader.valid_loader_type.valid_readonly
 virsh.boot.by_seabios.positive_test.options.boot.hd.file_disk.boot_dev.os_loader.valid_loader_type.no_readonly
@@ -41,7 +41,7 @@ The number of test cases was reduced from 52 to 26.
 
 The filter can be double checked by
 ```bash
-# python3 filter_avocado_list.py -t virsh.boot,boot_integration > original.list
-# python3 filter_avocado_list.py virsh.boot,boot_integration > filtered.list
+# python3 minimal_avocado_list.py -t virsh.boot,boot_integration > original.list
+# python3 minimal_avocado_list.py virsh.boot,boot_integration > filtered.list
 diff -y filtered.list original.list
 ```

--- a/minimal_avocado_list.py
+++ b/minimal_avocado_list.py
@@ -1,7 +1,7 @@
 import re
 import subprocess
 import sys
-from filter import pairwise
+from minimal_filter import minimal
 
 # holds the vt only filter
 ONLY = []
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             print(name)
         sys.exit(0)
 
-    filtered_test_names = pairwise(test_names)
+    filtered_test_names = minimal(test_names)
     for name in filtered_test_names:
         print(name)
 

--- a/minimal_filter.py
+++ b/minimal_filter.py
@@ -4,7 +4,7 @@ def parts(line):
     p = line.split(SEP)
     return p
 
-def pairwise(lines):
+def minimal(lines):
     diag = []
 
     for line in lines:
@@ -46,9 +46,9 @@ test_lines = [
 
 class TestDiagonal(unittest.TestCase):
 
-    def test_pairwise(self):
-        pairwised = pairwise(test_lines)
-        self.assertEqual(pairwised, ["a1.b1.c1", "a1.b1.c2", "a1.b2.c1", "a1.d1"])
+    def test_minimal(self):
+        minimald = minimal(test_lines)
+        self.assertEqual(minimald, ["a1.b1.c1", "a1.b1.c2", "a1.b2.c1", "a1.d1"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In order to avoid confusion, substitute pairwise by minimal.
Although the minimal filter does not always lead to the absolute
minimal set, it's still a better choice of words.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>