### PR TITLE
avocado_list: randomize selection before returning

### DIFF
--- a/avocado_list.py
+++ b/avocado_list.py
@@ -1,3 +1,4 @@
+import random
 import re
 import subprocess
 import sys
@@ -9,16 +10,32 @@ PRINT_ORIGINAL = False
 SHOW_STATS = False
 APPLY_FILTER = None
 OPTIONS = None
-TEST_TYPE = "avocado-vt"
+TEST_TYPE = "VT"
 
 def print_help(exit_code):
     print(sys.argv[0] + " [-t] [-s] <-p|-m> [<vt-options>] <--vt-only-filter argument>")
+    print()
+    print(" The command calls avocado to list test cases and then applies an algorithm to reduce the list of tests, for")
+    print(" example by selecting only 2-way coverage over the available variant names (option -p).")
+    print(" Please note, the current implementation assumes that avocado-vt test cases are listed with the 'VT' test type.")
+    print(" If your avocado version uses another type, please adjust the script `TEST_TYPE` accordingly. You can identify")
+    print(" the test type by running a valid avocado list and check the output.")
     print()
     print(" <vt-options> are additional filters enclosed by quotes, e.g. '--vt-type libvirt --vt-machine-type s390-virtio'")
     print(" <vt-only-filter> is a comma separated list of test names")
     print(" by passing flag -t the avocado command result is printed and not filtered")
     print(" by passing flag -s the number of original test names and filtered ones are shown")
     print(" -p selects the pairwise filter selecting all available test cases with maximal coverage of pairs, -s selects the minimal filter selecting all available test cases covering at least all variants")
+    print(" EXAMPLE:")
+    print()
+    print("  The following command avocado list to obtain only those test cases for 'boot_integration' that are applicable")
+    print("  the s390-virtio machine type, selects 2-way variant coverage and displays statistics.")
+    print()
+    print("   python avocado_list.py -s -p '--vt-machine-type s390-virtio --vt-type libvirt' boot_integration")
+    print()
+    print("  By skipping the statistics you can create a file to use later as your test selection:")
+    print()
+    print("   python avocado_list.py -p '--vt-machine-type s390-virtio --vt-type libvirt' boot_integration > test_list.only")
     sys.exit(exit_code)
 
 def parse_args():
@@ -76,6 +93,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     filtered_test_names = APPLY_FILTER(test_names)
+    random.shuffle(filtered_test_names)
     for name in filtered_test_names:
         print(name)
 


### PR DESCRIPTION
Before printing the test case selection, randomize it.

Also, add some details to the command's doc.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>