### PR TITLE
process_avocado_filters: add script to generate vt-only-filters

### DIFF
--- a/avocado_list.py
+++ b/avocado_list.py
@@ -10,7 +10,7 @@ PRINT_ORIGINAL = False
 SHOW_STATS = False
 APPLY_FILTER = None
 OPTIONS = None
-TEST_TYPE = "VT"
+TEST_TYPE = "avocado-vt" # older versions of avocado might use 'VT'
 
 def print_help(exit_code):
     print(sys.argv[0] + " [-t] [-s] <-p|-m> [<vt-options>] <--vt-only-filter argument>")

--- a/process_avocado_filters.py
+++ b/process_avocado_filters.py
@@ -1,0 +1,71 @@
+"""
+This script takes as input a list of job names.
+
+It expects vt-no-filters and vt-only-filters to be
+defined in files of the same name, suffixed accordingly
+with ".only" or ".no".
+
+For each job name it will call avocado with these filters
+and additional arguments to create a new vt-only-filters
+for execution on s390x.
+
+The script supposes that the avocado_list.py script can
+be called successfully, e.g. in a python venv where
+avocado has been bootstrapped with --vt-type libvirt
+previously.
+"""
+from os import path
+import sys
+from os import popen
+import yaml
+
+def get_config(config_path):
+    """
+    Sample config file:
+
+    output_dir: /tmp/job-filters
+    job_names:
+        - function-cpu
+        - function-virtual_disk
+    """
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def write_file(output_path, content):
+    with open(output_path, 'w') as f:
+        f.write(content)
+
+
+def create_file(job_name, output_dir):
+    """
+    Creates a new file to include the vt-only-filters on s390x
+    in output_dir. It assumes that for the job name there are
+    already two files containing the full original vt-no-filters
+    and vt-only-filters with corresponding suffixes in the same path.
+    """
+
+    no_file_path = path.join(output_dir, job_name + ".no")
+    only_file_path = path.join(output_dir, job_name + ".only")
+
+    cmd_no_filter = "paste -s -d, %s" % no_file_path
+    no_filter = popen(cmd_no_filter).read().strip('\n')
+
+    cmd_only_filter = "paste -s -d, %s" % only_file_path
+    only_filter = popen(cmd_only_filter).read().strip('\n')
+
+    cmd = ("python avocado_list.py -m '--vt-type libvirt"
+           " --vt-no-filter \"%s\" --vt-machine-type s390-virtio'"
+           " \"%s\"" % (no_filter, only_filter))
+    s390x_only = popen(cmd).read().strip('\n')
+
+    write_file(path.join(output_dir, job_name + "-s390x.only"), s390x_only)
+
+def create_files(config_path):
+    config = get_config(config_path)
+    for job_name in config['job_names']:
+        create_file(job_name, config['output_dir'])
+
+
+if __name__ == "__main__":
+    create_files(sys.argv[1])


### PR DESCRIPTION
For s390x, we want to use a minimal subset of the Cartesian product
of all variants in tp-libvirt that have been previously defined via
vt-only-filters and vt-no-filters.

Add a script that takes that input and creates a new vt-only-filter
applicable on s390-only and writes it to a file ending in "-s390x.only".

Furthermore, add the minor change to update avocado's prefix for vt
test cases with a note about the legacy value.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>