### PR TITLE
process_avocado_filters: minor fix

### DIFF
--- a/process_avocado_filters.py
+++ b/process_avocado_filters.py
@@ -14,10 +14,12 @@ be called successfully, e.g. in a python venv where
 avocado has been bootstrapped with --vt-type libvirt
 previously.
 """
-from os import path
+import re
 import sys
-from os import popen
 import yaml
+
+from os import path
+from os import popen
 
 def get_config(config_path):
     """
@@ -44,15 +46,18 @@ def create_file(job_name, output_dir):
     already two files containing the full original vt-no-filters
     and vt-only-filters with corresponding suffixes in the same path.
     """
+    whitespace = re.compile(r'\s+')
 
     no_file_path = path.join(output_dir, job_name + ".no")
     only_file_path = path.join(output_dir, job_name + ".only")
 
     cmd_no_filter = "paste -s -d, %s" % no_file_path
-    no_filter = popen(cmd_no_filter).read().strip('\n')
+    no_filter = popen(cmd_no_filter).read()
+    no_filter = re.sub(whitespace, '', no_filter)
 
     cmd_only_filter = "paste -s -d, %s" % only_file_path
-    only_filter = popen(cmd_only_filter).read().strip('\n')
+    only_filter = popen(cmd_only_filter).read()
+    only_filter = re.sub(whitespace, '', only_filter)
 
     cmd = ("python avocado_list.py -m '--vt-type libvirt"
            " --vt-no-filter \"%s\" --vt-machine-type s390-virtio'"


### PR DESCRIPTION
Whitespace in the input files made it into the vt filters.
Hence, no test cases are found.

Fix it by removing all whitespace occurrences from the filter
definition string before passing it to avocado.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>