### PR TITLE
process_avocado_filters: sort output before writing to disk

### DIFF
--- a/process_avocado_filters.py
+++ b/process_avocado_filters.py
@@ -61,7 +61,7 @@ def create_file(job_name, output_dir):
 
     cmd = ("python avocado_list.py -m '--vt-type libvirt"
            " --vt-no-filter \"%s\" --vt-machine-type s390-virtio'"
-           " \"%s\"" % (no_filter, only_filter))
+           " \"%s\" | sort" % (no_filter, only_filter))
     s390x_only = popen(cmd).read().strip('\n')
 
     write_file(path.join(output_dir, job_name + "-s390x.only"), s390x_only)


### PR DESCRIPTION
By sorting the only files, it's easier to spot scope changes.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>