### PR TITLE
avocado_list: random list before filtering

### DIFF
--- a/avocado_list.py
+++ b/avocado_list.py
@@ -92,8 +92,8 @@ if __name__ == '__main__':
             print(name)
         sys.exit(0)
 
+    random.shuffle(test_names)
     filtered_test_names = APPLY_FILTER(test_names)
-    random.shuffle(filtered_test_names)
     for name in filtered_test_names:
         print(name)
 


### PR DESCRIPTION
Previously, the list was randomized after filtering which had therefore no impact on the selection of test cases. Randomize the list before filtering to assure the order of all test cases is random and therefore the filter gives different results.